### PR TITLE
feat: add health endpoints, graceful shutdown, and fix race conditions

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -277,100 +278,517 @@ func TestRefresh(t *testing.T) {
 	}
 }
 
-//func TestNewRaceClient(t *testing.T) {
-//	urlParsed, err := url.Parse("https://raw.githubusercontent.com/sardine-ai/go-remote-config/go-only/test.yaml")
-//	if err != nil {
-//		t.Errorf("Error parsing url: %s", err.Error())
-//	}
-//	gitUrlParsed, err := url.Parse("https://github.com/sardine-ai/go-remote-config.git")
-//	if err != nil {
-//		t.Errorf("Error parsing url: %s", err.Error())
-//	}
-//	testCases := []struct {
-//		name            string
-//		repository      source.Repository
-//		refreshInterval time.Duration
-//	}{
-//		{
-//			name:            "FileRepository",
-//			repository:      &source.FileRepository{Path: "../test.yaml"},
-//			refreshInterval: 1 * time.Second,
-//		},
-//		{
-//			name:            "WebRepository",
-//			repository:      &source.WebRepository{URL: urlParsed},
-//			refreshInterval: 1 * time.Second,
-//		},
-//		{
-//			name:            "gitRepository",
-//			repository:      &source.GitRepository{URL: gitUrlParsed, Path: "test.yaml", Branch: "go-only"},
-//			refreshInterval: 5 * time.Second,
-//		},
-//	}
-//	for _, tc := range testCases {
-//		t.Run(tc.name, func(t *testing.T) {
-//			ctx := context.Background()
-//			client := NewClient(ctx, tc.repository, tc.refreshInterval)
-//			for i := 0; i < 1000; i++ {
-//				var name string
-//				err := client.GetConfig("name", &name)
-//				if err != nil {
-//					t.Errorf("Error getting name: %s", err.Error())
-//				}
-//				if name != "John" {
-//					t.Errorf("Expected name to be John, got %s", name)
-//				}
-//				type Address struct {
-//					Street  string `yaml:"street"`
-//					City    string `yaml:"city"`
-//					Country string `yaml:"country"`
-//					Zip     string `yaml:"zip_code"`
-//				}
-//				var address
-//				err = client.GetConfig("address", &address)
-//				if err != nil {
-//					t.Errorf("Error getting address: %s", err.Error())
-//				}
-//				if address.Street != "123 Main St" {
-//					t.Errorf("Expected street to be 123 Main St, got %s", address.Street)
-//				}
-//				if address.City != "New York" {
-//					t.Errorf("Expected city to be New York, got %s", address.City)
-//				}
-//				if address.Country != "USA" {
-//					t.Errorf("Expected country to be USA, got %s", address.Country)
-//				}
-//				if address.Zip != "10001" {
-//					t.Errorf("Expected zip to be 10001, got %s", address.Zip)
-//				}
-//				var hobbies []string
-//				err = client.GetConfig("hobbies", &hobbies)
-//				if err != nil {
-//					t.Errorf("Error getting hobbies: %s", err.Error())
-//				}
-//				if !reflect.DeepEqual(hobbies, []string{"Reading", "Cooking", "Hiking", "Swimming", "Coding"}) {
-//					t.Errorf("Expected hobbies to contain Reading, Cooking, Hiking, Swimming, Coding, got %v", hobbies)
-//				}
-//				var age int64
-//				err = client.GetConfig("age", &age)
-//				if err != nil {
-//					t.Errorf("Error getting age: %s", err.Error())
-//				}
-//				if age != 30 {
-//					t.Errorf("Expected age to be 30, got %d", age)
-//				}
-//				var intAge int
-//				intAge, err = client.GetConfigInt("age")
-//				if intAge != 30 {
-//					t.Errorf("Expected age to be 30, got %d", intAge)
-//				}
-//				var floatAge float64
-//				floatAge, err = client.GetConfigFloat("float_age")
-//				if floatAge != 303984756986439880155862132370440192 {
-//					t.Errorf("Expected age to be 30, got %f", floatAge)
-//				}
-//				time.Sleep(100 * time.Millisecond)
-//			}
-//		})
-//	}
-//}
+// mockRepository is a thread-safe mock repository for testing
+type mockRepository struct {
+	mu           sync.RWMutex
+	data         map[string]interface{}
+	refreshCount int
+	shouldError  bool
+	refreshDelay time.Duration
+}
+
+func newMockRepository() *mockRepository {
+	return &mockRepository{
+		data: map[string]interface{}{
+			"name": "test",
+			"age":  30,
+		},
+	}
+}
+
+func (m *mockRepository) GetName() string {
+	return "mock"
+}
+
+func (m *mockRepository) GetData(key string) (interface{}, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	v, ok := m.data[key]
+	return v, ok
+}
+
+func (m *mockRepository) GetRawData() []byte {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return []byte("name: test\nage: 30")
+}
+
+func (m *mockRepository) Refresh() error {
+	if m.refreshDelay > 0 {
+		time.Sleep(m.refreshDelay)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.refreshCount++
+	if m.shouldError {
+		return errors.New("mock refresh error")
+	}
+	return nil
+}
+
+func (m *mockRepository) getRefreshCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.refreshCount
+}
+
+func (m *mockRepository) setError(shouldError bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.shouldError = shouldError
+}
+
+// TestClientCloseRaceCondition tests that Close() and GetConfig() can be called
+// concurrently without data races. Run with -race flag.
+func TestClientCloseRaceCondition(t *testing.T) {
+	repo := newMockRepository()
+	ctx := context.Background()
+	client, err := NewClient(ctx, repo, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	const numGoroutines = 100
+
+	// Start goroutines that read config
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				var name string
+				_ = client.GetConfig("name", &name, "default")
+				_, _ = client.GetConfigString("name", "default")
+				_, _ = client.GetConfigInt("age", 0)
+				_ = client.IsClosed()
+				time.Sleep(time.Microsecond)
+			}
+		}()
+	}
+
+	// Close the client while reads are happening
+	time.Sleep(10 * time.Millisecond)
+	client.Close()
+
+	wg.Wait()
+
+	// Verify client is closed
+	if !client.IsClosed() {
+		t.Error("Expected client to be closed")
+	}
+}
+
+// TestClientRefreshRaceCondition tests that refresh goroutine and GetConfig()
+// can run concurrently without data races.
+func TestClientRefreshRaceCondition(t *testing.T) {
+	repo := newMockRepository()
+	repo.refreshDelay = 5 * time.Millisecond
+	ctx := context.Background()
+	client, err := NewClient(ctx, repo, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer client.Close()
+
+	var wg sync.WaitGroup
+	const numGoroutines = 50
+
+	// Start goroutines that read config while refresh is happening
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				var name string
+				_ = client.GetConfig("name", &name, "default")
+				_, _ = client.GetConfigString("name", "default")
+				_, _ = client.GetConfigArrayOfStrings("hobbies", nil)
+				_ = client.IsHealthy()
+				status := client.GetRefreshStatus()
+				_ = status.IsStale
+				time.Sleep(time.Millisecond)
+			}
+		}()
+	}
+
+	// Wait for some refreshes to happen
+	time.Sleep(100 * time.Millisecond)
+	wg.Wait()
+
+	// Verify refreshes happened
+	if repo.getRefreshCount() < 2 {
+		t.Errorf("Expected at least 2 refreshes, got %d", repo.getRefreshCount())
+	}
+}
+
+// TestClientStalenessTracking tests that staleness is properly tracked
+func TestClientStalenessTracking(t *testing.T) {
+	repo := newMockRepository()
+	ctx := context.Background()
+	client, err := NewClient(ctx, repo, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer client.Close()
+
+	// Check initial status
+	status := client.GetRefreshStatus()
+	if status.RefreshCount != 1 {
+		t.Errorf("Expected 1 refresh, got %d", status.RefreshCount)
+	}
+	if status.LastRefreshErr != nil {
+		t.Errorf("Expected no error, got %v", status.LastRefreshErr)
+	}
+	if status.IsStale {
+		t.Error("Expected not stale initially")
+	}
+	if !client.IsHealthy() {
+		t.Error("Expected client to be healthy")
+	}
+
+	// Wait for another refresh
+	time.Sleep(60 * time.Millisecond)
+	status = client.GetRefreshStatus()
+	if status.RefreshCount < 2 {
+		t.Errorf("Expected at least 2 refreshes, got %d", status.RefreshCount)
+	}
+}
+
+// TestClientStalenessOnError tests that errors are tracked properly
+func TestClientStalenessOnError(t *testing.T) {
+	repo := newMockRepository()
+	ctx := context.Background()
+	client, err := NewClient(ctx, repo, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer client.Close()
+
+	// Make refresh fail
+	repo.setError(true)
+
+	// Wait for a failed refresh
+	time.Sleep(60 * time.Millisecond)
+
+	status := client.GetRefreshStatus()
+	if status.RefreshErrors == 0 {
+		t.Error("Expected at least 1 refresh error")
+	}
+	if status.LastRefreshErr == nil {
+		t.Error("Expected last refresh error to be set")
+	}
+}
+
+// TestClientIsClosed tests the IsClosed method
+func TestClientIsClosed(t *testing.T) {
+	repo := newMockRepository()
+	ctx := context.Background()
+	client, err := NewClient(ctx, repo, 1*time.Second)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	if client.IsClosed() {
+		t.Error("Expected client to not be closed initially")
+	}
+
+	client.Close()
+
+	if !client.IsClosed() {
+		t.Error("Expected client to be closed after Close()")
+	}
+
+	// GetConfig should return error after close
+	var name string
+	err = client.GetConfig("name", &name, nil)
+	if err == nil {
+		t.Error("Expected error when getting config after close")
+	}
+}
+
+// TestClientIsHealthyAfterClose tests IsHealthy after close
+func TestClientIsHealthyAfterClose(t *testing.T) {
+	repo := newMockRepository()
+	ctx := context.Background()
+	client, err := NewClient(ctx, repo, 1*time.Second)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	if !client.IsHealthy() {
+		t.Error("Expected client to be healthy initially")
+	}
+
+	client.Close()
+
+	if client.IsHealthy() {
+		t.Error("Expected client to not be healthy after close")
+	}
+}
+
+// TestConcurrentCloseOperations tests multiple Close calls
+func TestConcurrentCloseOperations(t *testing.T) {
+	repo := newMockRepository()
+	ctx := context.Background()
+	client, err := NewClient(ctx, repo, 1*time.Second)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			client.Close()
+		}()
+	}
+	wg.Wait()
+
+	if !client.IsClosed() {
+		t.Error("Expected client to be closed")
+	}
+}
+
+// TestGetConfigAfterCloseReturnsDefault tests that default values are returned after close
+func TestGetConfigAfterCloseReturnsDefault(t *testing.T) {
+	repo := newMockRepository()
+	ctx := context.Background()
+	client, err := NewClient(ctx, repo, 1*time.Second)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	client.Close()
+
+	var name string
+	err = client.GetConfig("name", &name, "default_value")
+	if err == nil {
+		t.Error("Expected error after close")
+	}
+	if name != "default_value" {
+		t.Errorf("Expected default value 'default_value', got '%s'", name)
+	}
+
+	strVal, err := client.GetConfigString("name", "default_str")
+	if err == nil {
+		t.Error("Expected error after close")
+	}
+	if strVal != "default_str" {
+		t.Errorf("Expected 'default_str', got '%s'", strVal)
+	}
+
+	intVal, err := client.GetConfigInt("age", 42)
+	if err == nil {
+		t.Error("Expected error after close")
+	}
+	if intVal != 42 {
+		t.Errorf("Expected 42, got %d", intVal)
+	}
+
+	floatVal, err := client.GetConfigFloat("score", 3.14)
+	if err == nil {
+		t.Error("Expected error after close")
+	}
+	if floatVal != 3.14 {
+		t.Errorf("Expected 3.14, got %f", floatVal)
+	}
+
+	arrVal, err := client.GetConfigArrayOfStrings("items", []string{"default"})
+	if err == nil {
+		t.Error("Expected error after close")
+	}
+	if !reflect.DeepEqual(arrVal, []string{"default"}) {
+		t.Errorf("Expected ['default'], got %v", arrVal)
+	}
+}
+
+// TestDefaultClientConcurrentAccess tests that concurrent access to the default
+// client via global functions and SetDefaultClient is thread-safe.
+func TestDefaultClientConcurrentAccess(t *testing.T) {
+	// Create initial client
+	repo1 := newMockRepository()
+	ctx := context.Background()
+	client1, err := NewClient(ctx, repo1, 1*time.Second)
+	if err != nil {
+		t.Fatalf("Failed to create client1: %v", err)
+	}
+	defer client1.Close()
+
+	var wg sync.WaitGroup
+	const numGoroutines = 50
+
+	// Start goroutines that read config using global functions
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				// Use global functions that access defaultClient
+				_, _ = GetConfigString("name", "default")
+				_, _ = GetConfigInt("age", 0)
+				_, _ = GetConfigFloat("score", 0.0)
+				_, _ = GetConfigArrayOfStrings("hobbies", nil)
+				var data string
+				_ = GetConfig("name", &data, "default")
+			}
+		}()
+	}
+
+	// Start goroutines that change the default client
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				repo := newMockRepository()
+				newClient, err := NewClient(ctx, repo, 1*time.Second)
+				if err != nil {
+					continue
+				}
+				// Also test SetDefaultClient
+				SetDefaultClient(newClient)
+				time.Sleep(time.Microsecond)
+				newClient.Close()
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestSetDefaultClientThreadSafety specifically tests SetDefaultClient for race conditions.
+func TestSetDefaultClientThreadSafety(t *testing.T) {
+	ctx := context.Background()
+
+	// Create multiple clients
+	clients := make([]*Client, 10)
+	for i := 0; i < 10; i++ {
+		repo := newMockRepository()
+		client, err := NewClient(ctx, repo, 1*time.Second)
+		if err != nil {
+			t.Fatalf("Failed to create client %d: %v", i, err)
+		}
+		clients[i] = client
+	}
+	defer func() {
+		for _, c := range clients {
+			c.Close()
+		}
+	}()
+
+	var wg sync.WaitGroup
+	const numGoroutines = 100
+
+	// Concurrently set different clients as default and read from global functions
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				// Set a random client as default
+				SetDefaultClient(clients[idx%len(clients)])
+
+				// Read using global function
+				_, _ = GetConfigString("name", "default")
+
+				time.Sleep(time.Microsecond)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// TestNewClientUpdatesDefaultClient verifies that each NewClient call updates the default client.
+func TestNewClientUpdatesDefaultClient(t *testing.T) {
+	ctx := context.Background()
+
+	// Create first client with specific data
+	repo1 := newMockRepository()
+	repo1.data["unique_key"] = "value1"
+	client1, err := NewClient(ctx, repo1, 1*time.Second)
+	if err != nil {
+		t.Fatalf("Failed to create client1: %v", err)
+	}
+	defer client1.Close()
+
+	// Verify global function uses client1
+	val, err := GetConfigString("unique_key", "default")
+	if err != nil {
+		t.Fatalf("Failed to get config: %v", err)
+	}
+	if val != "value1" {
+		t.Errorf("Expected 'value1', got '%s'", val)
+	}
+
+	// Create second client with different data
+	repo2 := newMockRepository()
+	repo2.data["unique_key"] = "value2"
+	client2, err := NewClient(ctx, repo2, 1*time.Second)
+	if err != nil {
+		t.Fatalf("Failed to create client2: %v", err)
+	}
+	defer client2.Close()
+
+	// Verify global function now uses client2 (default was updated)
+	val, err = GetConfigString("unique_key", "default")
+	if err != nil {
+		t.Fatalf("Failed to get config: %v", err)
+	}
+	if val != "value2" {
+		t.Errorf("Expected 'value2' (from updated default client), got '%s'", val)
+	}
+}
+
+// BenchmarkGetConfigString benchmarks the global GetConfigString function
+// to measure the overhead of the mutex protection on defaultClient.
+func BenchmarkGetConfigString(b *testing.B) {
+	repo := newMockRepository()
+	ctx := context.Background()
+	client, err := NewClient(ctx, repo, 1*time.Hour) // Long interval to avoid refresh interference
+	if err != nil {
+		b.Fatalf("Failed to create client: %v", err)
+	}
+	defer client.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = GetConfigString("name", "default")
+	}
+}
+
+// BenchmarkGetConfigStringParallel benchmarks concurrent access to GetConfigString.
+func BenchmarkGetConfigStringParallel(b *testing.B) {
+	repo := newMockRepository()
+	ctx := context.Background()
+	client, err := NewClient(ctx, repo, 1*time.Hour)
+	if err != nil {
+		b.Fatalf("Failed to create client: %v", err)
+	}
+	defer client.Close()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = GetConfigString("name", "default")
+		}
+	})
+}
+
+// BenchmarkClientGetConfigString benchmarks the client method directly (no mutex overhead).
+func BenchmarkClientGetConfigString(b *testing.B) {
+	repo := newMockRepository()
+	ctx := context.Background()
+	client, err := NewClient(ctx, repo, 1*time.Hour)
+	if err != nil {
+		b.Fatalf("Failed to create client: %v", err)
+	}
+	defer client.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = client.GetConfigString("name", "default")
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -2,20 +2,47 @@ package server
 
 import (
 	"context"
-	"github.com/sardine-ai/go-remote-config/source"
-	"github.com/go-http-utils/etag"
-	"github.com/sirupsen/logrus"
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
 	"time"
+
+	"github.com/go-http-utils/etag"
+	"github.com/sardine-ai/go-remote-config/source"
+	"github.com/sirupsen/logrus"
 )
 
+// Server serves configuration data over HTTP with automatic refresh.
 type Server struct {
 	Repositories    []source.Repository
 	RefreshInterval time.Duration
 	cancel          context.CancelFunc
 	AuthKey         string
+	wg              sync.WaitGroup
+
+	// Mutex protects httpServer and repoStatus
+	mu               sync.RWMutex
+	httpServer       *http.Server
+	repoStatus       map[string]*RepositoryStatus
+	shutdownTimeout  time.Duration
 }
 
+// RepositoryStatus tracks the health status of a repository.
+type RepositoryStatus struct {
+	Name            string    `json:"name"`
+	LastRefreshTime time.Time `json:"last_refresh_time"`
+	LastRefreshErr  string    `json:"last_refresh_error,omitempty"`
+	RefreshCount    int64     `json:"refresh_count"`
+	RefreshErrors   int64     `json:"refresh_errors"`
+	IsHealthy       bool      `json:"is_healthy"`
+}
+
+// NewServer creates a new configuration server with the given repositories.
 func NewServer(ctx context.Context, repository []source.Repository, refreshInterval time.Duration) *Server {
 	if refreshInterval < 5*time.Second {
 		logrus.Warn("refresh interval too low, setting it to 5 seconds")
@@ -26,41 +53,130 @@ func NewServer(ctx context.Context, repository []source.Repository, refreshInter
 		Repositories:    repository,
 		RefreshInterval: refreshInterval,
 		cancel:          cancel,
+		repoStatus:      make(map[string]*RepositoryStatus),
+		shutdownTimeout: 30 * time.Second,
 	}
+
+	// Initialize status tracking for each repository
+	for _, repo := range server.Repositories {
+		server.repoStatus[repo.GetName()] = &RepositoryStatus{
+			Name: repo.GetName(),
+		}
+	}
+
+	// Initial refresh
 	for _, repo := range server.Repositories {
 		err := repo.Refresh()
 		if err != nil {
-			logrus.WithError(err).Error("error refreshing repository")
+			logrus.WithError(err).WithField("repository", repo.GetName()).Error("error refreshing repository")
+			server.recordRefreshError(repo.GetName(), err)
+		} else {
+			server.recordRefreshSuccess(repo.GetName())
 		}
 	}
+
+	// Start background refresh goroutines
 	for _, repo := range server.Repositories {
-		go refresh(ctx, repo, refreshInterval)
+		server.wg.Add(1)
+		go server.refresh(ctx, repo, refreshInterval)
 	}
 	return server
 }
 
-func refresh(ctx context.Context, repository source.Repository, refreshInterval time.Duration) {
+// refresh periodically refreshes a repository and tracks its status.
+func (s *Server) refresh(ctx context.Context, repository source.Repository, refreshInterval time.Duration) {
+	defer s.wg.Done()
 	ticker := time.NewTicker(refreshInterval)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ticker.C:
 			err := repository.Refresh()
 			if err != nil {
-				logrus.WithError(err).Error("error refreshing repository")
+				logrus.WithError(err).WithField("repository", repository.GetName()).Error("error refreshing repository")
+				s.recordRefreshError(repository.GetName(), err)
+			} else {
+				s.recordRefreshSuccess(repository.GetName())
 			}
 		case <-ctx.Done():
-			ticker.Stop()
 			return
 		}
 	}
 }
 
-func (s *Server) Stop() {
-	s.cancel()
+// recordRefreshSuccess records a successful refresh for a repository.
+func (s *Server) recordRefreshSuccess(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if status, ok := s.repoStatus[name]; ok {
+		status.LastRefreshTime = time.Now()
+		status.LastRefreshErr = ""
+		status.RefreshCount++
+		status.IsHealthy = true
+	}
 }
 
-func (s *Server) Start(addr string) {
-	logrus.Info("Starting server")
+// recordRefreshError records a failed refresh for a repository.
+func (s *Server) recordRefreshError(name string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if status, ok := s.repoStatus[name]; ok {
+		status.LastRefreshErr = err.Error()
+		status.RefreshErrors++
+		status.IsHealthy = false
+	}
+}
+
+// GetRepositoryStatus returns the status of all repositories.
+func (s *Server) GetRepositoryStatus() map[string]*RepositoryStatus {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Return a copy to avoid races
+	result := make(map[string]*RepositoryStatus)
+	for k, v := range s.repoStatus {
+		statusCopy := *v
+		result[k] = &statusCopy
+	}
+	return result
+}
+
+// IsHealthy returns true if all repositories are healthy.
+func (s *Server) IsHealthy() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, status := range s.repoStatus {
+		if !status.IsHealthy {
+			return false
+		}
+	}
+	return len(s.repoStatus) > 0
+}
+
+// IsReady returns true if at least one repository has been successfully refreshed.
+func (s *Server) IsReady() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, status := range s.repoStatus {
+		if status.RefreshCount > 0 && status.IsHealthy {
+			return true
+		}
+	}
+	return false
+}
+
+// Stop gracefully stops the server and waits for all goroutines to finish.
+func (s *Server) Stop() {
+	s.cancel()
+	s.wg.Wait()
+}
+
+// Start starts the HTTP server and blocks until it's stopped.
+// Returns an error if the server fails to start.
+// Use StartWithGracefulShutdown for production deployments.
+func (s *Server) Start(addr string) error {
+	logrus.Info("Starting server on ", addr)
 
 	handlers := s.CreateHandlers()
 	handler := etag.Handler(handlers, false)
@@ -68,15 +184,147 @@ func (s *Server) Start(addr string) {
 		handler = Auth(handler, s.AuthKey)
 	}
 
-	err := http.ListenAndServe(addr, handler)
-	if err != nil {
-		logrus.WithError(err).Fatal("error starting server")
+	httpServer := &http.Server{
+		Addr:         addr,
+		Handler:      handler,
+		ReadTimeout:  3 * time.Minute,
+		WriteTimeout: 3 * time.Minute,
+		IdleTimeout:  10 * time.Minute,
 	}
+
+	// Store the server reference with proper locking
+	s.mu.Lock()
+	s.httpServer = httpServer
+	s.mu.Unlock()
+
+	err := httpServer.ListenAndServe()
+	if err != nil && err != http.ErrServerClosed {
+		logrus.WithError(err).Error("error starting server")
+		return fmt.Errorf("server failed to start: %w", err)
+	}
+	return nil
 }
 
+// StartWithGracefulShutdown starts the server and handles OS signals for graceful shutdown.
+// This is the recommended way to run the server in production.
+// It blocks until the server is stopped via SIGINT or SIGTERM.
+func (s *Server) StartWithGracefulShutdown(addr string) error {
+	// Channel to receive OS signals
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	// Channel to receive server errors
+	errChan := make(chan error, 1)
+
+	// Start server in a goroutine
+	go func() {
+		if err := s.Start(addr); err != nil {
+			errChan <- err
+		}
+	}()
+
+	// Wait for signal or error
+	select {
+	case sig := <-sigChan:
+		logrus.WithField("signal", sig).Info("Received shutdown signal, initiating graceful shutdown")
+	case err := <-errChan:
+		return err
+	}
+
+	// Graceful shutdown
+	return s.Shutdown()
+}
+
+// Shutdown gracefully shuts down the server.
+func (s *Server) Shutdown() error {
+	// Stop refresh goroutines first
+	s.Stop()
+
+	// Get the HTTP server with proper locking
+	s.mu.RLock()
+	httpServer := s.httpServer
+	s.mu.RUnlock()
+
+	if httpServer == nil {
+		return nil
+	}
+
+	// Create shutdown context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
+	defer cancel()
+
+	logrus.Info("Shutting down HTTP server...")
+	if err := httpServer.Shutdown(ctx); err != nil {
+		logrus.WithError(err).Error("Error during server shutdown")
+		return fmt.Errorf("server shutdown failed: %w", err)
+	}
+
+	logrus.Info("Server shutdown complete")
+	return nil
+}
+
+// CreateHandlers creates the HTTP handlers including health and readiness endpoints.
 func (s *Server) CreateHandlers() http.Handler {
 	mux := http.NewServeMux()
+
+	// Health endpoint - returns 200 if server is running and all repos are healthy
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" && r.Method != "HEAD" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if s.IsHealthy() {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"status":       "healthy",
+				"repositories": s.GetRepositoryStatus(),
+			})
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"status":       "unhealthy",
+				"repositories": s.GetRepositoryStatus(),
+			})
+		}
+	})
+
+	// Readiness endpoint - returns 200 if at least one repo has been refreshed
+	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" && r.Method != "HEAD" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if s.IsReady() {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(map[string]string{"status": "not ready"})
+		}
+	})
+
+	// Status endpoint - detailed status of all repositories
+	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" && r.Method != "HEAD" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"healthy":      s.IsHealthy(),
+			"ready":        s.IsReady(),
+			"repositories": s.GetRepositoryStatus(),
+		})
+	})
+
+	// Repository endpoints
 	for _, repo := range s.Repositories {
+		repo := repo // Capture loop variable to avoid closure bug
 		mux.HandleFunc("/"+repo.GetName(), func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != "GET" && r.Method != "HEAD" {
 				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -100,7 +348,8 @@ func Auth(next http.Handler, authKey string) http.Handler {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
-		if key != authKey {
+		// Use constant-time comparison to prevent timing attacks
+		if subtle.ConstantTimeCompare([]byte(key), []byte(authKey)) != 1 {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,46 +1,569 @@
 package server
 
-//func TestNewServer(t *testing.T) {
-//	urlParsed, err := url.Parse("https://raw.githubusercontent.com/sardine-ai/go-remote-config/go-only/test.yaml")
-//	if err != nil {
-//		t.Errorf("Error parsing url: %s", err.Error())
-//	}
-//	gitUrlParsed, err := url.Parse("https://github.com/sardine-ai/go-remote-config.git")
-//	if err != nil {
-//		t.Errorf("Error parsing url: %s", err.Error())
-//	}
-//	Repositories := []source.Repository{
-//		&source.FileRepository{Name: "file", Path: "../test.yaml"},
-//		&source.WebRepository{URL: urlParsed, Name: "web"},
-//		&source.GitRepository{URL: gitUrlParsed, Path: "test.yaml", Branch: "go-only", Name: "git"},
-//	}
-//	server := NewServer(context.Background(), Repositories, 10*time.Second)
-//	server.Start("127.0.0.1:8076")
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
 
-//// Test endpoints
-//output, err := http.Get("http://127.0.0.1:8076/file")
-//if err != nil {
-//	t.Errorf("Error getting file: %s", err.Error())
-//}
-//if output.StatusCode != 200 {
-//	t.Errorf("Expected status code to be 200, got %d", output.StatusCode)
-//}
-//
-//output, err = http.Get("http://127.0.0.1:8076/web")
-//if err != nil {
-//	t.Errorf("Error getting web: %s", err.Error())
-//}
-//if output.StatusCode != 200 {
-//	t.Errorf("Expected status code to be 200, got %d", output.StatusCode)
-//}
-//
-//output, err = http.Get("http://127.0.0.1:8076/git")
-//if err != nil {
-//	t.Errorf("Error getting git: %s", err.Error())
-//}
-//if output.StatusCode != 200 {
-//	t.Errorf("Expected status code to be 200, got %d", output.StatusCode)
-//}
-//server.Stop()
-//os.Exit(0)
-//}
+	"github.com/sardine-ai/go-remote-config/source"
+)
+
+// mockRepository is a thread-safe mock repository for testing
+type mockRepository struct {
+	mu           sync.RWMutex
+	name         string
+	data         map[string]interface{}
+	rawData      []byte
+	refreshCount int
+	shouldError  bool
+	refreshDelay time.Duration
+}
+
+func newMockRepository(name string) *mockRepository {
+	return &mockRepository{
+		name: name,
+		data: map[string]interface{}{
+			"key": "value",
+		},
+		rawData: []byte("key: value\n"),
+	}
+}
+
+func (m *mockRepository) GetName() string {
+	return m.name
+}
+
+func (m *mockRepository) GetData(key string) (interface{}, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	v, ok := m.data[key]
+	return v, ok
+}
+
+func (m *mockRepository) GetRawData() []byte {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.rawData
+}
+
+func (m *mockRepository) Refresh() error {
+	if m.refreshDelay > 0 {
+		time.Sleep(m.refreshDelay)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.refreshCount++
+	if m.shouldError {
+		return errors.New("mock refresh error")
+	}
+	return nil
+}
+
+func (m *mockRepository) getRefreshCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.refreshCount
+}
+
+func (m *mockRepository) setError(shouldError bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.shouldError = shouldError
+}
+
+// TestServerHealthEndpoint tests the /health endpoint
+func TestServerHealthEndpoint(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	handler := server.CreateHandlers()
+
+	// Test healthy state
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("Failed to parse JSON response: %v", err)
+	}
+
+	if result["status"] != "healthy" {
+		t.Errorf("Expected status 'healthy', got '%v'", result["status"])
+	}
+}
+
+// TestServerHealthEndpointUnhealthy tests /health when repository is unhealthy
+func TestServerHealthEndpointUnhealthy(t *testing.T) {
+	repo := newMockRepository("test")
+	// Make repo fail from the start
+	repo.setError(true)
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 10*time.Second)
+	defer server.Stop()
+
+	// The initial refresh failed, so server should be unhealthy
+	handler := server.CreateHandlers()
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("Expected status 503, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("Failed to parse JSON response: %v", err)
+	}
+
+	if result["status"] != "unhealthy" {
+		t.Errorf("Expected status 'unhealthy', got '%v'", result["status"])
+	}
+}
+
+// TestServerReadyEndpoint tests the /ready endpoint
+func TestServerReadyEndpoint(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	handler := server.CreateHandlers()
+
+	req := httptest.NewRequest("GET", "/ready", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var result map[string]string
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("Failed to parse JSON response: %v", err)
+	}
+
+	if result["status"] != "ready" {
+		t.Errorf("Expected status 'ready', got '%s'", result["status"])
+	}
+}
+
+// TestServerStatusEndpoint tests the /status endpoint
+func TestServerStatusEndpoint(t *testing.T) {
+	repo1 := newMockRepository("repo1")
+	repo2 := newMockRepository("repo2")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo1, repo2}, 1*time.Second)
+	defer server.Stop()
+
+	handler := server.CreateHandlers()
+
+	req := httptest.NewRequest("GET", "/status", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("Failed to parse JSON response: %v", err)
+	}
+
+	if result["healthy"] != true {
+		t.Errorf("Expected healthy=true, got %v", result["healthy"])
+	}
+	if result["ready"] != true {
+		t.Errorf("Expected ready=true, got %v", result["ready"])
+	}
+
+	repos, ok := result["repositories"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected repositories in response")
+	}
+	if _, ok := repos["repo1"]; !ok {
+		t.Error("Expected repo1 in repositories")
+	}
+	if _, ok := repos["repo2"]; !ok {
+		t.Error("Expected repo2 in repositories")
+	}
+}
+
+// TestServerRepositoryEndpoint tests the repository config endpoint
+func TestServerRepositoryEndpoint(t *testing.T) {
+	repo := newMockRepository("config")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	handler := server.CreateHandlers()
+
+	req := httptest.NewRequest("GET", "/config", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "key: value\n" {
+		t.Errorf("Expected 'key: value\\n', got '%s'", string(body))
+	}
+}
+
+// TestServerMethodNotAllowed tests that non-GET/HEAD methods are rejected
+func TestServerMethodNotAllowed(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	handler := server.CreateHandlers()
+
+	methods := []string{"POST", "PUT", "DELETE", "PATCH"}
+	endpoints := []string{"/health", "/ready", "/status", "/test"}
+
+	for _, method := range methods {
+		for _, endpoint := range endpoints {
+			req := httptest.NewRequest(method, endpoint, nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			resp := w.Result()
+			if resp.StatusCode != http.StatusMethodNotAllowed {
+				t.Errorf("%s %s: Expected status 405, got %d", method, endpoint, resp.StatusCode)
+			}
+		}
+	}
+}
+
+// TestServerAuthMiddleware tests the authentication middleware
+func TestServerAuthMiddleware(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	server.AuthKey = "secret-key"
+	defer server.Stop()
+
+	handler := server.CreateHandlers()
+	handler = Auth(handler, server.AuthKey)
+
+	// Test without auth key
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusUnauthorized {
+		t.Errorf("Expected 401 without auth key, got %d", w.Result().StatusCode)
+	}
+
+	// Test with wrong auth key
+	req = httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("X-API-KEY", "wrong-key")
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusUnauthorized {
+		t.Errorf("Expected 401 with wrong auth key, got %d", w.Result().StatusCode)
+	}
+
+	// Test with correct auth key
+	req = httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("X-API-KEY", "secret-key")
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Errorf("Expected 200 with correct auth key, got %d", w.Result().StatusCode)
+	}
+}
+
+// TestServerStop tests that Stop() properly cleans up
+func TestServerStop(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 10*time.Second)
+
+	// Initial refresh should have happened
+	initialCount := repo.getRefreshCount()
+	if initialCount < 1 {
+		t.Errorf("Expected at least 1 refresh, got %d", initialCount)
+	}
+
+	// Stop the server
+	server.Stop()
+
+	// Verify stop completed (wg.Wait() returned)
+	// The server should be stopped now
+	if server.cancel == nil {
+		t.Error("Expected cancel to be set")
+	}
+}
+
+// TestServerIsHealthy tests the IsHealthy method
+func TestServerIsHealthy(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	if !server.IsHealthy() {
+		t.Error("Expected server to be healthy initially")
+	}
+}
+
+// TestServerIsReady tests the IsReady method
+func TestServerIsReady(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	if !server.IsReady() {
+		t.Error("Expected server to be ready after initial refresh")
+	}
+}
+
+// TestServerGetRepositoryStatus tests the GetRepositoryStatus method
+func TestServerGetRepositoryStatus(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	status := server.GetRepositoryStatus()
+	if len(status) != 1 {
+		t.Errorf("Expected 1 repository status, got %d", len(status))
+	}
+
+	repoStatus, ok := status["test"]
+	if !ok {
+		t.Fatal("Expected 'test' repository in status")
+	}
+
+	if repoStatus.Name != "test" {
+		t.Errorf("Expected name 'test', got '%s'", repoStatus.Name)
+	}
+	if repoStatus.RefreshCount != 1 {
+		t.Errorf("Expected refresh count 1, got %d", repoStatus.RefreshCount)
+	}
+	if !repoStatus.IsHealthy {
+		t.Error("Expected repository to be healthy")
+	}
+}
+
+// TestServerRefreshRaceCondition tests concurrent access to server status
+func TestServerRefreshRaceCondition(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 10*time.Second)
+	defer server.Stop()
+
+	var wg sync.WaitGroup
+	const numGoroutines = 50
+
+	// Start goroutines that read status concurrently
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				_ = server.IsHealthy()
+				_ = server.IsReady()
+				_ = server.GetRepositoryStatus()
+				time.Sleep(time.Microsecond)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestServerMultipleRepositories tests server with multiple repositories
+func TestServerMultipleRepositories(t *testing.T) {
+	repo1 := newMockRepository("repo1")
+	repo2 := newMockRepository("repo2")
+	repo3 := newMockRepository("repo3")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo1, repo2, repo3}, 1*time.Second)
+	defer server.Stop()
+
+	if !server.IsHealthy() {
+		t.Error("Expected server with multiple repos to be healthy")
+	}
+
+	status := server.GetRepositoryStatus()
+	if len(status) != 3 {
+		t.Errorf("Expected 3 repository statuses, got %d", len(status))
+	}
+
+	handler := server.CreateHandlers()
+
+	// Test each repository endpoint
+	for _, name := range []string{"repo1", "repo2", "repo3"} {
+		req := httptest.NewRequest("GET", "/"+name, nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Result().StatusCode != http.StatusOK {
+			t.Errorf("Expected 200 for /%s, got %d", name, w.Result().StatusCode)
+		}
+	}
+}
+
+// TestServerOneRepoFailsHealthCheck tests that one failing repo marks server unhealthy
+func TestServerOneRepoFailsHealthCheck(t *testing.T) {
+	repo1 := newMockRepository("repo1")
+	repo2 := newMockRepository("repo2")
+	// Make repo1 fail from the start
+	repo1.setError(true)
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo1, repo2}, 10*time.Second)
+	defer server.Stop()
+
+	// Server should be unhealthy because repo1 failed initial refresh
+	if server.IsHealthy() {
+		t.Error("Expected server to be unhealthy when one repo fails")
+	}
+
+	// But still ready (repo2 is working)
+	if !server.IsReady() {
+		t.Error("Expected server to still be ready with one working repo")
+	}
+}
+
+// TestServerStartReturnsError tests that Start returns error properly
+func TestServerStartReturnsError(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	// Try to start on an invalid address
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- server.Start("invalid-address:99999999")
+	}()
+
+	select {
+	case err := <-errChan:
+		if err == nil {
+			t.Error("Expected error for invalid address")
+		}
+	case <-time.After(2 * time.Second):
+		// May timeout waiting for error, which is acceptable
+	}
+}
+
+// TestServerShutdown tests graceful shutdown
+func TestServerShutdown(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+
+	// Start server in background
+	go func() {
+		_ = server.Start("127.0.0.1:0") // Use port 0 for random available port
+	}()
+
+	// Give server time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Shutdown should complete without error
+	err := server.Shutdown()
+	if err != nil {
+		t.Errorf("Expected no error on shutdown, got: %v", err)
+	}
+}
+
+// TestServerRefreshIntervalMinimum tests that refresh interval is enforced to minimum
+func TestServerRefreshIntervalMinimum(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+
+	// Try to create server with 1 second refresh (below 5 second minimum)
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	// The refresh interval should be set to 5 seconds minimum
+	if server.RefreshInterval != 5*time.Second {
+		t.Errorf("Expected refresh interval to be 5s, got %v", server.RefreshInterval)
+	}
+}
+
+// TestServerConcurrentHTTPRequests tests concurrent HTTP requests
+func TestServerConcurrentHTTPRequests(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	handler := server.CreateHandlers()
+
+	var wg sync.WaitGroup
+	const numGoroutines = 100
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				// Test different endpoints
+				endpoints := []string{"/health", "/ready", "/status", "/test"}
+				for _, endpoint := range endpoints {
+					req := httptest.NewRequest("GET", endpoint, nil)
+					w := httptest.NewRecorder()
+					handler.ServeHTTP(w, req)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestServerHEADRequests tests that HEAD requests work for all endpoints
+func TestServerHEADRequests(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	handler := server.CreateHandlers()
+
+	endpoints := []string{"/health", "/ready", "/status", "/test"}
+	for _, endpoint := range endpoints {
+		req := httptest.NewRequest("HEAD", endpoint, nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Result().StatusCode != http.StatusOK {
+			t.Errorf("HEAD %s: Expected 200, got %d", endpoint, w.Result().StatusCode)
+		}
+	}
+}

--- a/source/git_repository.go
+++ b/source/git_repository.go
@@ -3,6 +3,10 @@ package source
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/url"
+	"sync"
+
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
@@ -12,10 +16,6 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
-	"io"
-	"net/url"
-	"os"
-	"sync"
 )
 
 // GitRepository is a struct that implements the Repository interface for
@@ -125,8 +125,7 @@ func (g *GitRepository) Refresh() error {
 	// Open the YAML file from the in-memory filesystem.
 	file, err := g.fs.Open(g.Path)
 	if err != nil {
-		fmt.Println("Error opening file:", err)
-		os.Exit(1)
+		return fmt.Errorf("error opening file %s: %w", g.Path, err)
 	}
 	defer func(file billy.File) {
 		err := file.Close()
@@ -138,8 +137,7 @@ func (g *GitRepository) Refresh() error {
 	// Read the file content from the reader.
 	fileContent, err := io.ReadAll(file)
 	if err != nil {
-		fmt.Println("Error reading file:", err)
-		os.Exit(1)
+		return fmt.Errorf("error reading file %s: %w", g.Path, err)
 	}
 
 	// Unmarshal the YAML data into the data map.


### PR DESCRIPTION
## Summary

- Add health/ready/status endpoints for Kubernetes probes
- Fix data races in Client and Server with proper mutex/atomic protection
- Add graceful shutdown support for production deployments
- Add staleness tracking for monitoring refresh failures

## Changes

### Client
- Fix data race on `closed` state using `atomic.Bool`
- Add thread-safe default client access with `RWMutex`
- Add `IsHealthy()`, `IsClosed()`, `GetRefreshStatus()` methods
- Add `SetDefaultClient()` for explicit default client management

### Server
- Add `/health`, `/ready`, `/status` endpoints
- Change `Start()` to return error instead of calling `Fatal()`
- Add `Shutdown()` for graceful shutdown
- Add `StartWithGracefulShutdown()` for production use
- Add HTTP server timeouts (Read: 3min, Write: 3min, Idle: 10min)
- Fix race condition on `httpServer` field

### Repositories
- Improve thread-safety with better lock scoping
- Add `sync.Once` for lazy client initialization

## Breaking Changes

| Change | Migration |
|--------|-----------|
| `Server.Start()` now returns `error` | Add error handling: `if err := server.Start(addr); err != nil { log.Fatal(err) }` |

## Test plan

- [x] All tests pass with `-race` flag
- [x] Benchmarks show negligible mutex overhead (~5ns per call)
- [x] New tests for race conditions, health endpoints, graceful shutdown