### PR TITLE
feat: add health endpoints, graceful shutdown, and fix race conditions

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -342,7 +342,7 @@ func (s *Server) CreateHandlers() http.Handler {
 func Auth(next http.Handler, authKey string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Skip auth for health check endpoints (needed for K8s probes)
-		if r.URL.Path == "/health" || r.URL.Path == "/ready" || r.URL.Path == "/status" {
+		if r.URL.Path == "/health" || r.URL.Path == "/ready" {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -2,20 +2,47 @@ package server
 
 import (
 	"context"
-	"github.com/sardine-ai/go-remote-config/source"
-	"github.com/go-http-utils/etag"
-	"github.com/sirupsen/logrus"
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
 	"time"
+
+	"github.com/go-http-utils/etag"
+	"github.com/sardine-ai/go-remote-config/source"
+	"github.com/sirupsen/logrus"
 )
 
+// Server serves configuration data over HTTP with automatic refresh.
 type Server struct {
 	Repositories    []source.Repository
 	RefreshInterval time.Duration
 	cancel          context.CancelFunc
 	AuthKey         string
+	wg              sync.WaitGroup
+
+	// Mutex protects httpServer and repoStatus
+	mu               sync.RWMutex
+	httpServer       *http.Server
+	repoStatus       map[string]*RepositoryStatus
+	shutdownTimeout  time.Duration
 }
 
+// RepositoryStatus tracks the health status of a repository.
+type RepositoryStatus struct {
+	Name            string    `json:"name"`
+	LastRefreshTime time.Time `json:"last_refresh_time"`
+	LastRefreshErr  string    `json:"last_refresh_error,omitempty"`
+	RefreshCount    int64     `json:"refresh_count"`
+	RefreshErrors   int64     `json:"refresh_errors"`
+	IsHealthy       bool      `json:"is_healthy"`
+}
+
+// NewServer creates a new configuration server with the given repositories.
 func NewServer(ctx context.Context, repository []source.Repository, refreshInterval time.Duration) *Server {
 	if refreshInterval < 5*time.Second {
 		logrus.Warn("refresh interval too low, setting it to 5 seconds")
@@ -26,41 +53,130 @@ func NewServer(ctx context.Context, repository []source.Repository, refreshInter
 		Repositories:    repository,
 		RefreshInterval: refreshInterval,
 		cancel:          cancel,
+		repoStatus:      make(map[string]*RepositoryStatus),
+		shutdownTimeout: 30 * time.Second,
 	}
+
+	// Initialize status tracking for each repository
+	for _, repo := range server.Repositories {
+		server.repoStatus[repo.GetName()] = &RepositoryStatus{
+			Name: repo.GetName(),
+		}
+	}
+
+	// Initial refresh
 	for _, repo := range server.Repositories {
 		err := repo.Refresh()
 		if err != nil {
-			logrus.WithError(err).Error("error refreshing repository")
+			logrus.WithError(err).WithField("repository", repo.GetName()).Error("error refreshing repository")
+			server.recordRefreshError(repo.GetName(), err)
+		} else {
+			server.recordRefreshSuccess(repo.GetName())
 		}
 	}
+
+	// Start background refresh goroutines
 	for _, repo := range server.Repositories {
-		go refresh(ctx, repo, refreshInterval)
+		server.wg.Add(1)
+		go server.refresh(ctx, repo, refreshInterval)
 	}
 	return server
 }
 
-func refresh(ctx context.Context, repository source.Repository, refreshInterval time.Duration) {
+// refresh periodically refreshes a repository and tracks its status.
+func (s *Server) refresh(ctx context.Context, repository source.Repository, refreshInterval time.Duration) {
+	defer s.wg.Done()
 	ticker := time.NewTicker(refreshInterval)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ticker.C:
 			err := repository.Refresh()
 			if err != nil {
-				logrus.WithError(err).Error("error refreshing repository")
+				logrus.WithError(err).WithField("repository", repository.GetName()).Error("error refreshing repository")
+				s.recordRefreshError(repository.GetName(), err)
+			} else {
+				s.recordRefreshSuccess(repository.GetName())
 			}
 		case <-ctx.Done():
-			ticker.Stop()
 			return
 		}
 	}
 }
 
-func (s *Server) Stop() {
-	s.cancel()
+// recordRefreshSuccess records a successful refresh for a repository.
+func (s *Server) recordRefreshSuccess(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if status, ok := s.repoStatus[name]; ok {
+		status.LastRefreshTime = time.Now()
+		status.LastRefreshErr = ""
+		status.RefreshCount++
+		status.IsHealthy = true
+	}
 }
 
-func (s *Server) Start(addr string) {
-	logrus.Info("Starting server")
+// recordRefreshError records a failed refresh for a repository.
+func (s *Server) recordRefreshError(name string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if status, ok := s.repoStatus[name]; ok {
+		status.LastRefreshErr = err.Error()
+		status.RefreshErrors++
+		status.IsHealthy = false
+	}
+}
+
+// GetRepositoryStatus returns the status of all repositories.
+func (s *Server) GetRepositoryStatus() map[string]*RepositoryStatus {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Return a copy to avoid races
+	result := make(map[string]*RepositoryStatus)
+	for k, v := range s.repoStatus {
+		statusCopy := *v
+		result[k] = &statusCopy
+	}
+	return result
+}
+
+// IsHealthy returns true if all repositories are healthy.
+func (s *Server) IsHealthy() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, status := range s.repoStatus {
+		if !status.IsHealthy {
+			return false
+		}
+	}
+	return len(s.repoStatus) > 0
+}
+
+// IsReady returns true if at least one repository has been successfully refreshed.
+func (s *Server) IsReady() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, status := range s.repoStatus {
+		if status.RefreshCount > 0 && status.IsHealthy {
+			return true
+		}
+	}
+	return false
+}
+
+// Stop gracefully stops the server and waits for all goroutines to finish.
+func (s *Server) Stop() {
+	s.cancel()
+	s.wg.Wait()
+}
+
+// Start starts the HTTP server and blocks until it's stopped.
+// Returns an error if the server fails to start.
+// Use StartWithGracefulShutdown for production deployments.
+func (s *Server) Start(addr string) error {
+	logrus.Info("Starting server on ", addr)
 
 	handlers := s.CreateHandlers()
 	handler := etag.Handler(handlers, false)
@@ -68,15 +184,147 @@ func (s *Server) Start(addr string) {
 		handler = Auth(handler, s.AuthKey)
 	}
 
-	err := http.ListenAndServe(addr, handler)
-	if err != nil {
-		logrus.WithError(err).Fatal("error starting server")
+	httpServer := &http.Server{
+		Addr:         addr,
+		Handler:      handler,
+		ReadTimeout:  3 * time.Minute,
+		WriteTimeout: 3 * time.Minute,
+		IdleTimeout:  10 * time.Minute,
 	}
+
+	// Store the server reference with proper locking
+	s.mu.Lock()
+	s.httpServer = httpServer
+	s.mu.Unlock()
+
+	err := httpServer.ListenAndServe()
+	if err != nil && err != http.ErrServerClosed {
+		logrus.WithError(err).Error("error starting server")
+		return fmt.Errorf("server failed to start: %w", err)
+	}
+	return nil
 }
 
+// StartWithGracefulShutdown starts the server and handles OS signals for graceful shutdown.
+// This is the recommended way to run the server in production.
+// It blocks until the server is stopped via SIGINT or SIGTERM.
+func (s *Server) StartWithGracefulShutdown(addr string) error {
+	// Channel to receive OS signals
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	// Channel to receive server errors
+	errChan := make(chan error, 1)
+
+	// Start server in a goroutine
+	go func() {
+		if err := s.Start(addr); err != nil {
+			errChan <- err
+		}
+	}()
+
+	// Wait for signal or error
+	select {
+	case sig := <-sigChan:
+		logrus.WithField("signal", sig).Info("Received shutdown signal, initiating graceful shutdown")
+	case err := <-errChan:
+		return err
+	}
+
+	// Graceful shutdown
+	return s.Shutdown()
+}
+
+// Shutdown gracefully shuts down the server.
+func (s *Server) Shutdown() error {
+	// Stop refresh goroutines first
+	s.Stop()
+
+	// Get the HTTP server with proper locking
+	s.mu.RLock()
+	httpServer := s.httpServer
+	s.mu.RUnlock()
+
+	if httpServer == nil {
+		return nil
+	}
+
+	// Create shutdown context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
+	defer cancel()
+
+	logrus.Info("Shutting down HTTP server...")
+	if err := httpServer.Shutdown(ctx); err != nil {
+		logrus.WithError(err).Error("Error during server shutdown")
+		return fmt.Errorf("server shutdown failed: %w", err)
+	}
+
+	logrus.Info("Server shutdown complete")
+	return nil
+}
+
+// CreateHandlers creates the HTTP handlers including health and readiness endpoints.
 func (s *Server) CreateHandlers() http.Handler {
 	mux := http.NewServeMux()
+
+	// Health endpoint - returns 200 if server is running and all repos are healthy
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" && r.Method != "HEAD" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if s.IsHealthy() {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"status":       "healthy",
+				"repositories": s.GetRepositoryStatus(),
+			})
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"status":       "unhealthy",
+				"repositories": s.GetRepositoryStatus(),
+			})
+		}
+	})
+
+	// Readiness endpoint - returns 200 if at least one repo has been refreshed
+	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" && r.Method != "HEAD" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if s.IsReady() {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(map[string]string{"status": "not ready"})
+		}
+	})
+
+	// Status endpoint - detailed status of all repositories
+	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" && r.Method != "HEAD" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"healthy":      s.IsHealthy(),
+			"ready":        s.IsReady(),
+			"repositories": s.GetRepositoryStatus(),
+		})
+	})
+
+	// Repository endpoints
 	for _, repo := range s.Repositories {
+		repo := repo // Capture loop variable to avoid closure bug
 		mux.HandleFunc("/"+repo.GetName(), func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != "GET" && r.Method != "HEAD" {
 				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -100,7 +348,8 @@ func Auth(next http.Handler, authKey string) http.Handler {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
-		if key != authKey {
+		// Use constant-time comparison to prevent timing attacks
+		if subtle.ConstantTimeCompare([]byte(key), []byte(authKey)) != 1 {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,46 +1,569 @@
 package server
 
-//func TestNewServer(t *testing.T) {
-//	urlParsed, err := url.Parse("https://raw.githubusercontent.com/sardine-ai/go-remote-config/go-only/test.yaml")
-//	if err != nil {
-//		t.Errorf("Error parsing url: %s", err.Error())
-//	}
-//	gitUrlParsed, err := url.Parse("https://github.com/sardine-ai/go-remote-config.git")
-//	if err != nil {
-//		t.Errorf("Error parsing url: %s", err.Error())
-//	}
-//	Repositories := []source.Repository{
-//		&source.FileRepository{Name: "file", Path: "../test.yaml"},
-//		&source.WebRepository{URL: urlParsed, Name: "web"},
-//		&source.GitRepository{URL: gitUrlParsed, Path: "test.yaml", Branch: "go-only", Name: "git"},
-//	}
-//	server := NewServer(context.Background(), Repositories, 10*time.Second)
-//	server.Start("127.0.0.1:8076")
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
 
-//// Test endpoints
-//output, err := http.Get("http://127.0.0.1:8076/file")
-//if err != nil {
-//	t.Errorf("Error getting file: %s", err.Error())
-//}
-//if output.StatusCode != 200 {
-//	t.Errorf("Expected status code to be 200, got %d", output.StatusCode)
-//}
-//
-//output, err = http.Get("http://127.0.0.1:8076/web")
-//if err != nil {
-//	t.Errorf("Error getting web: %s", err.Error())
-//}
-//if output.StatusCode != 200 {
-//	t.Errorf("Expected status code to be 200, got %d", output.StatusCode)
-//}
-//
-//output, err = http.Get("http://127.0.0.1:8076/git")
-//if err != nil {
-//	t.Errorf("Error getting git: %s", err.Error())
-//}
-//if output.StatusCode != 200 {
-//	t.Errorf("Expected status code to be 200, got %d", output.StatusCode)
-//}
-//server.Stop()
-//os.Exit(0)
-//}
+	"github.com/sardine-ai/go-remote-config/source"
+)
+
+// mockRepository is a thread-safe mock repository for testing
+type mockRepository struct {
+	mu           sync.RWMutex
+	name         string
+	data         map[string]interface{}
+	rawData      []byte
+	refreshCount int
+	shouldError  bool
+	refreshDelay time.Duration
+}
+
+func newMockRepository(name string) *mockRepository {
+	return &mockRepository{
+		name: name,
+		data: map[string]interface{}{
+			"key": "value",
+		},
+		rawData: []byte("key: value\n"),
+	}
+}
+
+func (m *mockRepository) GetName() string {
+	return m.name
+}
+
+func (m *mockRepository) GetData(key string) (interface{}, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	v, ok := m.data[key]
+	return v, ok
+}
+
+func (m *mockRepository) GetRawData() []byte {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.rawData
+}
+
+func (m *mockRepository) Refresh() error {
+	if m.refreshDelay > 0 {
+		time.Sleep(m.refreshDelay)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.refreshCount++
+	if m.shouldError {
+		return errors.New("mock refresh error")
+	}
+	return nil
+}
+
+func (m *mockRepository) getRefreshCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.refreshCount
+}
+
+func (m *mockRepository) setError(shouldError bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.shouldError = shouldError
+}
+
+// TestServerHealthEndpoint tests the /health endpoint
+func TestServerHealthEndpoint(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	handler := server.CreateHandlers()
+
+	// Test healthy state
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("Failed to parse JSON response: %v", err)
+	}
+
+	if result["status"] != "healthy" {
+		t.Errorf("Expected status 'healthy', got '%v'", result["status"])
+	}
+}
+
+// TestServerHealthEndpointUnhealthy tests /health when repository is unhealthy
+func TestServerHealthEndpointUnhealthy(t *testing.T) {
+	repo := newMockRepository("test")
+	// Make repo fail from the start
+	repo.setError(true)
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 10*time.Second)
+	defer server.Stop()
+
+	// The initial refresh failed, so server should be unhealthy
+	handler := server.CreateHandlers()
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("Expected status 503, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("Failed to parse JSON response: %v", err)
+	}
+
+	if result["status"] != "unhealthy" {
+		t.Errorf("Expected status 'unhealthy', got '%v'", result["status"])
+	}
+}
+
+// TestServerReadyEndpoint tests the /ready endpoint
+func TestServerReadyEndpoint(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	handler := server.CreateHandlers()
+
+	req := httptest.NewRequest("GET", "/ready", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var result map[string]string
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("Failed to parse JSON response: %v", err)
+	}
+
+	if result["status"] != "ready" {
+		t.Errorf("Expected status 'ready', got '%s'", result["status"])
+	}
+}
+
+// TestServerStatusEndpoint tests the /status endpoint
+func TestServerStatusEndpoint(t *testing.T) {
+	repo1 := newMockRepository("repo1")
+	repo2 := newMockRepository("repo2")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo1, repo2}, 1*time.Second)
+	defer server.Stop()
+
+	handler := server.CreateHandlers()
+
+	req := httptest.NewRequest("GET", "/status", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("Failed to parse JSON response: %v", err)
+	}
+
+	if result["healthy"] != true {
+		t.Errorf("Expected healthy=true, got %v", result["healthy"])
+	}
+	if result["ready"] != true {
+		t.Errorf("Expected ready=true, got %v", result["ready"])
+	}
+
+	repos, ok := result["repositories"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected repositories in response")
+	}
+	if _, ok := repos["repo1"]; !ok {
+		t.Error("Expected repo1 in repositories")
+	}
+	if _, ok := repos["repo2"]; !ok {
+		t.Error("Expected repo2 in repositories")
+	}
+}
+
+// TestServerRepositoryEndpoint tests the repository config endpoint
+func TestServerRepositoryEndpoint(t *testing.T) {
+	repo := newMockRepository("config")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	handler := server.CreateHandlers()
+
+	req := httptest.NewRequest("GET", "/config", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "key: value\n" {
+		t.Errorf("Expected 'key: value\\n', got '%s'", string(body))
+	}
+}
+
+// TestServerMethodNotAllowed tests that non-GET/HEAD methods are rejected
+func TestServerMethodNotAllowed(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	handler := server.CreateHandlers()
+
+	methods := []string{"POST", "PUT", "DELETE", "PATCH"}
+	endpoints := []string{"/health", "/ready", "/status", "/test"}
+
+	for _, method := range methods {
+		for _, endpoint := range endpoints {
+			req := httptest.NewRequest(method, endpoint, nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			resp := w.Result()
+			if resp.StatusCode != http.StatusMethodNotAllowed {
+				t.Errorf("%s %s: Expected status 405, got %d", method, endpoint, resp.StatusCode)
+			}
+		}
+	}
+}
+
+// TestServerAuthMiddleware tests the authentication middleware
+func TestServerAuthMiddleware(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	server.AuthKey = "secret-key"
+	defer server.Stop()
+
+	handler := server.CreateHandlers()
+	handler = Auth(handler, server.AuthKey)
+
+	// Test without auth key
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusUnauthorized {
+		t.Errorf("Expected 401 without auth key, got %d", w.Result().StatusCode)
+	}
+
+	// Test with wrong auth key
+	req = httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("X-API-KEY", "wrong-key")
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusUnauthorized {
+		t.Errorf("Expected 401 with wrong auth key, got %d", w.Result().StatusCode)
+	}
+
+	// Test with correct auth key
+	req = httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("X-API-KEY", "secret-key")
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Errorf("Expected 200 with correct auth key, got %d", w.Result().StatusCode)
+	}
+}
+
+// TestServerStop tests that Stop() properly cleans up
+func TestServerStop(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 10*time.Second)
+
+	// Initial refresh should have happened
+	initialCount := repo.getRefreshCount()
+	if initialCount < 1 {
+		t.Errorf("Expected at least 1 refresh, got %d", initialCount)
+	}
+
+	// Stop the server
+	server.Stop()
+
+	// Verify stop completed (wg.Wait() returned)
+	// The server should be stopped now
+	if server.cancel == nil {
+		t.Error("Expected cancel to be set")
+	}
+}
+
+// TestServerIsHealthy tests the IsHealthy method
+func TestServerIsHealthy(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	if !server.IsHealthy() {
+		t.Error("Expected server to be healthy initially")
+	}
+}
+
+// TestServerIsReady tests the IsReady method
+func TestServerIsReady(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	if !server.IsReady() {
+		t.Error("Expected server to be ready after initial refresh")
+	}
+}
+
+// TestServerGetRepositoryStatus tests the GetRepositoryStatus method
+func TestServerGetRepositoryStatus(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	status := server.GetRepositoryStatus()
+	if len(status) != 1 {
+		t.Errorf("Expected 1 repository status, got %d", len(status))
+	}
+
+	repoStatus, ok := status["test"]
+	if !ok {
+		t.Fatal("Expected 'test' repository in status")
+	}
+
+	if repoStatus.Name != "test" {
+		t.Errorf("Expected name 'test', got '%s'", repoStatus.Name)
+	}
+	if repoStatus.RefreshCount != 1 {
+		t.Errorf("Expected refresh count 1, got %d", repoStatus.RefreshCount)
+	}
+	if !repoStatus.IsHealthy {
+		t.Error("Expected repository to be healthy")
+	}
+}
+
+// TestServerRefreshRaceCondition tests concurrent access to server status
+func TestServerRefreshRaceCondition(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 10*time.Second)
+	defer server.Stop()
+
+	var wg sync.WaitGroup
+	const numGoroutines = 50
+
+	// Start goroutines that read status concurrently
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				_ = server.IsHealthy()
+				_ = server.IsReady()
+				_ = server.GetRepositoryStatus()
+				time.Sleep(time.Microsecond)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestServerMultipleRepositories tests server with multiple repositories
+func TestServerMultipleRepositories(t *testing.T) {
+	repo1 := newMockRepository("repo1")
+	repo2 := newMockRepository("repo2")
+	repo3 := newMockRepository("repo3")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo1, repo2, repo3}, 1*time.Second)
+	defer server.Stop()
+
+	if !server.IsHealthy() {
+		t.Error("Expected server with multiple repos to be healthy")
+	}
+
+	status := server.GetRepositoryStatus()
+	if len(status) != 3 {
+		t.Errorf("Expected 3 repository statuses, got %d", len(status))
+	}
+
+	handler := server.CreateHandlers()
+
+	// Test each repository endpoint
+	for _, name := range []string{"repo1", "repo2", "repo3"} {
+		req := httptest.NewRequest("GET", "/"+name, nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Result().StatusCode != http.StatusOK {
+			t.Errorf("Expected 200 for /%s, got %d", name, w.Result().StatusCode)
+		}
+	}
+}
+
+// TestServerOneRepoFailsHealthCheck tests that one failing repo marks server unhealthy
+func TestServerOneRepoFailsHealthCheck(t *testing.T) {
+	repo1 := newMockRepository("repo1")
+	repo2 := newMockRepository("repo2")
+	// Make repo1 fail from the start
+	repo1.setError(true)
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo1, repo2}, 10*time.Second)
+	defer server.Stop()
+
+	// Server should be unhealthy because repo1 failed initial refresh
+	if server.IsHealthy() {
+		t.Error("Expected server to be unhealthy when one repo fails")
+	}
+
+	// But still ready (repo2 is working)
+	if !server.IsReady() {
+		t.Error("Expected server to still be ready with one working repo")
+	}
+}
+
+// TestServerStartReturnsError tests that Start returns error properly
+func TestServerStartReturnsError(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	// Try to start on an invalid address
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- server.Start("invalid-address:99999999")
+	}()
+
+	select {
+	case err := <-errChan:
+		if err == nil {
+			t.Error("Expected error for invalid address")
+		}
+	case <-time.After(2 * time.Second):
+		// May timeout waiting for error, which is acceptable
+	}
+}
+
+// TestServerShutdown tests graceful shutdown
+func TestServerShutdown(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+
+	// Start server in background
+	go func() {
+		_ = server.Start("127.0.0.1:0") // Use port 0 for random available port
+	}()
+
+	// Give server time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Shutdown should complete without error
+	err := server.Shutdown()
+	if err != nil {
+		t.Errorf("Expected no error on shutdown, got: %v", err)
+	}
+}
+
+// TestServerRefreshIntervalMinimum tests that refresh interval is enforced to minimum
+func TestServerRefreshIntervalMinimum(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+
+	// Try to create server with 1 second refresh (below 5 second minimum)
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	// The refresh interval should be set to 5 seconds minimum
+	if server.RefreshInterval != 5*time.Second {
+		t.Errorf("Expected refresh interval to be 5s, got %v", server.RefreshInterval)
+	}
+}
+
+// TestServerConcurrentHTTPRequests tests concurrent HTTP requests
+func TestServerConcurrentHTTPRequests(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	handler := server.CreateHandlers()
+
+	var wg sync.WaitGroup
+	const numGoroutines = 100
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				// Test different endpoints
+				endpoints := []string{"/health", "/ready", "/status", "/test"}
+				for _, endpoint := range endpoints {
+					req := httptest.NewRequest("GET", endpoint, nil)
+					w := httptest.NewRecorder()
+					handler.ServeHTTP(w, req)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestServerHEADRequests tests that HEAD requests work for all endpoints
+func TestServerHEADRequests(t *testing.T) {
+	repo := newMockRepository("test")
+	ctx := context.Background()
+	server := NewServer(ctx, []source.Repository{repo}, 1*time.Second)
+	defer server.Stop()
+
+	handler := server.CreateHandlers()
+
+	endpoints := []string{"/health", "/ready", "/status", "/test"}
+	for _, endpoint := range endpoints {
+		req := httptest.NewRequest("HEAD", endpoint, nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Result().StatusCode != http.StatusOK {
+			t.Errorf("HEAD %s: Expected 200, got %d", endpoint, w.Result().StatusCode)
+		}
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -315,7 +315,7 @@ func TestServerHealthEndpointsBypassAuth(t *testing.T) {
 	handler = Auth(handler, server.AuthKey)
 
 	// Health endpoints should work without auth key
-	healthEndpoints := []string{"/health", "/ready", "/status"}
+	healthEndpoints := []string{"/health", "/ready"}
 	for _, endpoint := range healthEndpoints {
 		req := httptest.NewRequest("GET", endpoint, nil)
 		w := httptest.NewRecorder()
@@ -326,13 +326,16 @@ func TestServerHealthEndpointsBypassAuth(t *testing.T) {
 		}
 	}
 
-	// Config endpoint should still require auth
-	req := httptest.NewRequest("GET", "/test", nil)
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, req)
+	// Status and config endpoints should still require auth
+	authRequiredEndpoints := []string{"/status", "/test"}
+	for _, endpoint := range authRequiredEndpoints {
+		req := httptest.NewRequest("GET", endpoint, nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
 
-	if w.Result().StatusCode != http.StatusUnauthorized {
-		t.Errorf("/test: Expected 401 without auth key, got %d", w.Result().StatusCode)
+		if w.Result().StatusCode != http.StatusUnauthorized {
+			t.Errorf("%s: Expected 401 without auth key, got %d", endpoint, w.Result().StatusCode)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Add health/readiness endpoints for Kubernetes, graceful shutdown support, and fix race conditions.

## Breaking Changes

| Change | Migration |
|--------|-----------|
| `Server.Start()` now returns `error` | Add error handling: `if err := server.Start(addr); err != nil { log.Fatal(err) }` |

## Changes

### Health Endpoints
- Add `/health` - returns 200 if all repos healthy, 503 otherwise
- Add `/ready` - returns 200 if at least one repo refreshed successfully
- Add `/status` - returns detailed status of all repositories

### Graceful Shutdown
- Add `Shutdown()` for graceful shutdown with configurable timeout
- Add `StartWithGracefulShutdown()` for production deployments (handles SIGINT/SIGTERM)

### Server Improvements
- Add HTTP server timeouts (Read: 3min, Write: 3min, Idle: 10min)
- Add per-repository health tracking with `RepositoryStatus` struct
- Add `IsHealthy()`, `IsReady()`, `GetRepositoryStatus()` methods
- Use constant-time comparison for auth key (prevent timing attacks)
- Add `WaitGroup` to track refresh goroutines

### Race Condition Fixes
- Fix race condition on `httpServer` field with mutex
- Add proper ticker cleanup with `defer ticker.Stop()`

## Test plan

- [x] All tests pass with `-race` flag
- [x] Tests for health/ready/status endpoints
- [x] Tests for graceful shutdown
- [x] Concurrent HTTP request tests